### PR TITLE
Fix 'conv2D' derivative (#331)

### DIFF
--- a/Sources/TensorFlow/Operators/NN.swift
+++ b/Sources/TensorFlow/Operators/NN.swift
@@ -185,7 +185,7 @@ func _vjpConv2DBackpropInput<Scalar: TensorFlowFloatingPoint>(
     let value = conv2DBackpropInput(x, shape: shape, filter: filter,
                                     strides: strides, padding: padding, dilations: dilations)
     return (value, { v in
-        (conv2DBackpropFilter(x, input: v, filterSizes: shape, strides: strides,
+        (conv2DBackpropFilter(x, input: v, filterSizes: filter.shapeTensor, strides: strides,
                               padding: padding, dilations: dilations),
          conv2D(v, filter: filter, strides: strides, padding: padding, dilations: dilations))
     })


### PR DESCRIPTION
`_vjpConv2DBackpropInput` should use the filter shape for `conv2DBackpropFilter`'s `filterSizes` parameter.